### PR TITLE
Use smaller logo

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -2,7 +2,7 @@
     <picture>
         <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/biomejs/resources/main/svg/slogan-dark-transparent.svg">
         <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/biomejs/resources/main/svg/slogan-light-transparent.svg">
-        <img alt="Shows the banner of Biome, with its logo and the phrase 'Toolchain of the web'." src="https://raw.githubusercontent.com/biomejs/resources/main/svg/slogan-light-transparent.svg" width="700">
+        <img alt="Shows the banner of Biome, with its logo and the phrase 'Toolchain of the web'." src="https://raw.githubusercontent.com/biomejs/resources/main/svg/slogan-light-transparent.svg" width="500">
     </picture>
 </p>
 


### PR DESCRIPTION
This pull request includes a small change to the `profile/README.md` file. The change reduces the width of the banner image from 700 to 500 pixels.

* [`profile/README.md`](diffhunk://#diff-0e83982cf6f4dabedcbf7b12029a56c6f4a728064ba99543fff8f227c0654b45L5-R5): Reduced the width of the banner image from 700 to 500 pixels.