### PR TITLE
chore: remove polar

### DIFF
--- a/FUNDING.yml
+++ b/FUNDING.yml
@@ -1,4 +1,3 @@
 github: [biomejs]
 open_collective: biome
-polar: biomejs
 thanks_dev: u/gh/biomejs


### PR DESCRIPTION
This PR removes Polar from the funding methods because they discontinued the funding feature for OSS projects.